### PR TITLE
Fix build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ cd to NGINX source directory & run this:
     make
     make install
 
-See this article about building nginx-rtmp with HLS support:
-https://github.com/arut/nginx-rtmp-module/wiki/Building-nginx-rtmp-with-HLS-support
-
-
 ### RTMP URL format
 
     rtmp://rtmp.example.com/app[/name]


### PR DESCRIPTION
Http ssl module must be enabled for build. Otherwise, gcc raises the following error:

src/http/ngx_http_request.c:1992:9: error: unknown type name 'ngx_http_ssl_srv_conf_t'; did you mean 'ngx_http_core_srv_conf_t'?
