### PR TITLE
Refresh stats page every 30 seconds

### DIFF
--- a/stat.xsl
+++ b/stat.xsl
@@ -15,6 +15,9 @@
             <a href="http://nginx.com">NGINX</a>&#160;<xsl:value-of select="/rtmp/version"/>,
             pid <xsl:value-of select="/rtmp/pid"/>,
             built <xsl:value-of select="/rtmp/built"/>&#160;<xsl:value-of select="/rtmp/compiler"/>
+            <script type="text/javascript">
+                setTimeout(function () { location.reload(true); }, 30000);
+            </script>
         </body>
     </html>
 </xsl:template>


### PR DESCRIPTION
I thought this might be useful for everyone. 

First tries to use the meta tag option to refresh the page made it unusable. So I had to find a different option. This javascript function should work in most browsers. 
It would probably also be possible to add a selector to choose between no refresh and a different timing of 5/10/30/60 seconds or similar. I could take a look at this next if you like the idea.
