### PR TITLE
avoid breaking the hls-stream when a broken ts is in the hls-folder

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -472,6 +472,13 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
 
     for (i = 0; i < ctx->nfrags; i++) {
         f = ngx_rtmp_hls_get_frag(s, i);
+
+        if(f->duration > 60*60*24 /*24 hours*/)
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 32, "found fragment with broken duration (%f seconds > 24 hours)", f->duration);
+            continue;
+        }
+
         if (f->duration > max_frag) {
             max_frag = (ngx_uint_t) (f->duration + .5);
         }
@@ -505,6 +512,12 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
 
     for (i = 0; i < ctx->nfrags; i++) {
         f = ngx_rtmp_hls_get_frag(s, i);
+
+        if(f->duration > 60*60*24 /*24 hours*/)
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 32, "found fragment with broken duration (%f seconds > 24 hours)", f->duration);
+            continue;
+        }
 
         p = ngx_snprintf(buffer, sizeof(buffer),
                          "%s"


### PR DESCRIPTION
those broken ts-files are repored with 'Duration N/A' by ffprobe; in the rtmp-code f->duration becomes huuuuuge (204963823041217 seconds). this patch fixes the issue (hls stream not playable by devices when a broken ts-snippet is present) by skipping these broken snippets.
