### PR TITLE
Loosen suffix enforcement

### DIFF
--- a/ngx_rtmp_play_module.c
+++ b/ngx_rtmp_play_module.c
@@ -860,9 +860,23 @@ ngx_rtmp_play_next_entry(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         ctx->file.fd = ngx_open_file(path, NGX_FILE_RDONLY, NGX_FILE_OPEN,
                                      NGX_FILE_DEFAULT_ACCESS);
 
+        /* try unsuffixed file name as fallback if adding suffix didn't work */
         if (ctx->file.fd == NGX_INVALID_FILE) {
             ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, ngx_errno,
-                           "play: error opening file '%s'", path);
+                           "play: error opening file '%s', trying without suffix",
+                           path);
+
+            p = ngx_snprintf(path, NGX_MAX_PATH, "%V/%s",
+                             pe->root, v->name + ctx->pfx_size);
+            *p = 0;
+
+            ctx->file.fd = ngx_open_file(path, NGX_FILE_RDONLY, NGX_FILE_OPEN,
+                                         NGX_FILE_DEFAULT_ACCESS);
+        }
+
+        if (ctx->file.fd == NGX_INVALID_FILE) {
+            ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, ngx_errno,
+                           "play: error opening fallback file '%s'", path);
             continue;
         }
 


### PR DESCRIPTION
At the minute a local file must use the exact format suffix (`flv` or `mp4`). This commit loosens that constraint, allowing a prefix to be used to specify the format and the filename to not use the standard format suffix (for instance, `mp4:test.mov`. The existing behaviour is preserved, it tries `test.mov.mp4` and then falls back on trying `test.mov` (the `.mov` extension I can see as a valid use case, in my particular case I do not have a file extension at all)

The only issue I can see (albeit with my limited experience of the pecularities of RTMP clients) is that it would be possible for a malicious user to force parsing an FLV as MP4 or vice versa
