### PR TITLE
Explicitly signal HE-AAC in DASH manifest

### DIFF
--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -412,7 +412,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
         p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_AUDIO,
                          &ctx->name,
                          codec_ctx->audio_codec_id == NGX_RTMP_AUDIO_AAC ?
-                         "40.2" : "6b",
+                         (codec_ctx->aac_sbr ? "40.5" : "40.2") : "6b",
                          codec_ctx->sample_rate,
                          (ngx_uint_t) (codec_ctx->audio_data_rate * 1000),
                          name, sep,


### PR DESCRIPTION
This works around [an issue](https://code.google.com/p/chromium/issues/detail?id=370927#c3) in the Chromium MediaSource implementation.

Chromium will not play a video when the audio track uses HE-AAC, unless it is explicitly signaled in the manifest.
