### PR TITLE
Don't truncate framerate for MPEG-DASH

### DIFF
--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -857,7 +857,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ctx->width = (ngx_uint_t) v.width;
     ctx->height = (ngx_uint_t) v.height;
     ctx->duration = (ngx_uint_t) v.duration;
-    ctx->frame_rate = (ngx_uint_t) v.frame_rate;
+    ctx->frame_rate = v.frame_rate;
     ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
     ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
     ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
@@ -869,7 +869,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_log_debug8(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
             "codec: data frame: "
-            "width=%ui height=%ui duration=%ui frame_rate=%ui "
+            "width=%ui height=%ui duration=%ui frame_rate=%.3f "
             "video=%s (%ui) audio=%s (%ui)",
             ctx->width, ctx->height, ctx->duration, ctx->frame_rate,
             ngx_rtmp_get_video_codec_name(ctx->video_codec_id),

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -53,7 +53,7 @@ typedef struct {
     ngx_uint_t                  width;
     ngx_uint_t                  height;
     ngx_uint_t                  duration;
-    ngx_uint_t                  frame_rate;
+    double                      frame_rate;
     ngx_uint_t                  video_data_rate;
     ngx_uint_t                  video_codec_id;
     ngx_uint_t                  audio_data_rate;

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -509,7 +509,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                               "%ui", codec->height) - buf);
                 NGX_RTMP_STAT_L("</height><frame_rate>");
                 NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
-                              "%ui", codec->frame_rate) - buf);
+                              "%.3f", codec->frame_rate) - buf);
                 NGX_RTMP_STAT_L("</frame_rate>");
 
                 cname = ngx_rtmp_get_video_codec_name(codec->video_codec_id);


### PR DESCRIPTION
When pushing 29.97fps RTMP streams via DASH, the manifest shows an
incorrect frame rate of "29", not "30000/1001" as it should be.

Happy to make any style changes you'd like (apologies for this being a little hacky). Thanks so much for your hard work on nginx-rtmp-module! :)