### PR TITLE
Support pass-through of data stream

### DIFF
--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -1129,6 +1129,9 @@ ngx_rtmp_live_postconfiguration(ngx_conf_t *cf)
     h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
     *h = ngx_rtmp_live_av;
 
+    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AMF_META]);
+    *h = ngx_rtmp_live_av;
+
     /* chain handlers */
 
     next_publish = ngx_rtmp_publish;

--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -1285,6 +1285,9 @@ ngx_rtmp_record_postconfiguration(ngx_conf_t *cf)
     h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
     *h = ngx_rtmp_record_av;
 
+    h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_AMF_META]);
+    *h = ngx_rtmp_record_av ;
+
     next_publish = ngx_rtmp_publish;
     ngx_rtmp_publish = ngx_rtmp_record_publish;
 


### PR DESCRIPTION
For both 'live' and 'record' modules, pass-through any NGX_RTMP_MSG_AMF_META packets that come through.

For example, ActionScript allows both 'onTextData' and 'onCuePoint' RPC calls
to be encoded as AMF and sent over the wire as part of the FLV spec.

This addresses #481.
