### PR TITLE
fix 'volatile' qualifiers error

### DIFF
--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -838,7 +838,7 @@ static ngx_int_t
 ngx_rtmp_init_process(ngx_cycle_t *cycle)
 {
 #if (nginx_version >= 1007005)
-    ngx_queue_init(&ngx_rtmp_init_queue);
+    ngx_queue_init((ngx_queue_t*) &ngx_rtmp_init_queue);
 #endif
     return NGX_OK;
 }

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -115,7 +115,7 @@ ngx_rtmp_stat_init_process(ngx_cycle_t *cycle)
      * so we can run posted events here
      */
 
-    ngx_event_process_posted(cycle, &ngx_rtmp_init_queue);
+    ngx_event_process_posted(cycle, (ngx_queue_t*) &ngx_rtmp_init_queue);
 
     return NGX_OK;
 }


### PR DESCRIPTION
I get the "volatile qualifiers" error when compiling in Windows VS 2010.

P.S. I am not familiar with C++. :smiley: 

![Error](http://imgur.com/hv6UsgG.png)