### PR TITLE
implement configurable file and directory create mode for hls/dash

### DIFF
--- a/hls/ngx_rtmp_mpegts.c
+++ b/hls/ngx_rtmp_mpegts.c
@@ -350,12 +350,11 @@ ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
 
 ngx_int_t
 ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
-    ngx_log_t *log)
+    ngx_uint_t access, ngx_log_t *log)
 {
     file->log = log;
 
-    file->fd = ngx_open_file(path, NGX_FILE_WRONLY, NGX_FILE_TRUNCATE,
-                             NGX_FILE_DEFAULT_ACCESS);
+    file->fd = ngx_open_file(path, NGX_FILE_WRONLY, NGX_FILE_TRUNCATE, access);
 
     if (file->fd == NGX_INVALID_FILE) {
         ngx_log_error(NGX_LOG_ERR, log, ngx_errno,

--- a/hls/ngx_rtmp_mpegts.h
+++ b/hls/ngx_rtmp_mpegts.h
@@ -37,7 +37,7 @@ typedef struct {
 ngx_int_t ngx_rtmp_mpegts_init_encryption(ngx_rtmp_mpegts_file_t *file,
     u_char *key, size_t key_len, uint64_t iv);
 ngx_int_t ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
-    ngx_log_t *log);
+    ngx_uint_t access, ngx_log_t *log);
 ngx_int_t ngx_rtmp_mpegts_close_file(ngx_rtmp_mpegts_file_t *file);
 ngx_int_t ngx_rtmp_mpegts_write_frame(ngx_rtmp_mpegts_file_t *file,
     ngx_rtmp_mpegts_frame_t *f, ngx_buf_t *b);

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -327,6 +327,7 @@ typedef struct ngx_rtmp_core_srv_conf_s {
     size_t                  out_queue;
     size_t                  out_cork;
     ngx_msec_t              buflen;
+    ngx_uint_t              file_access;
 
     ngx_rtmp_conf_ctx_t    *ctx;
 } ngx_rtmp_core_srv_conf_t;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -157,6 +157,13 @@ static ngx_command_t  ngx_rtmp_core_commands[] = {
       offsetof(ngx_rtmp_core_srv_conf_t, buflen),
       NULL },
 
+    { ngx_string("file_access"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE123,
+      ngx_conf_set_access_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_core_srv_conf_t, file_access),
+      NULL },
+
       ngx_null_command
 };
 
@@ -249,6 +256,7 @@ ngx_rtmp_core_create_srv_conf(ngx_conf_t *cf)
     conf->publish_time_fix = NGX_CONF_UNSET;
     conf->buflen = NGX_CONF_UNSET_MSEC;
     conf->busy = NGX_CONF_UNSET;
+    conf->file_access = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -277,6 +285,8 @@ ngx_rtmp_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->publish_time_fix, prev->publish_time_fix, 1);
     ngx_conf_merge_msec_value(conf->buflen, prev->buflen, 1000);
     ngx_conf_merge_value(conf->busy, prev->busy, 0);
+    ngx_conf_merge_uint_value(conf->file_access, prev->file_access,
+            NGX_FILE_DEFAULT_ACCESS);
 
     if (prev->pool == NULL) {
         prev->pool = ngx_create_pool(4096, &cf->cycle->new_log);

--- a/ngx_rtmp_play_module.c
+++ b/ngx_rtmp_play_module.c
@@ -811,12 +811,14 @@ static ngx_int_t
 ngx_rtmp_play_next_entry(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
     ngx_rtmp_play_app_conf_t   *pacf;
+    ngx_rtmp_core_srv_conf_t   *cscf;
     ngx_rtmp_play_ctx_t        *ctx;
     ngx_rtmp_play_entry_t      *pe;
     u_char                     *p;
     static u_char               path[NGX_MAX_PATH + 1];
 
     pacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_play_module);
+    cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     ctx = ngx_rtmp_get_module_ctx(s, ngx_rtmp_play_module);
 
@@ -864,7 +866,7 @@ ngx_rtmp_play_next_entry(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
         *p = 0;
 
         ctx->file.fd = ngx_open_file(path, NGX_FILE_RDONLY, NGX_FILE_OPEN,
-                                     NGX_FILE_DEFAULT_ACCESS);
+                                     cscf->file_access);
 
         if (ctx->file.fd == NGX_INVALID_FILE) {
             ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, ngx_errno,

--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -436,6 +436,7 @@ ngx_rtmp_record_node_open(ngx_rtmp_session_t *s,
                           ngx_rtmp_record_rec_ctx_t *rctx)
 {
     ngx_rtmp_record_app_conf_t *rracf;
+    ngx_rtmp_core_srv_conf_t   *cscf;
     ngx_err_t                   err;
     ngx_str_t                   path;
     ngx_int_t                   mode, create_mode;
@@ -449,6 +450,8 @@ ngx_rtmp_record_node_open(ngx_rtmp_session_t *s,
     if (rctx->file.fd != NGX_INVALID_FILE) {
         return NGX_AGAIN;
     }
+
+    cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "record: %V opening", &rracf->id);
@@ -467,7 +470,7 @@ ngx_rtmp_record_node_open(ngx_rtmp_session_t *s,
     rctx->file.offset = 0;
     rctx->file.log = s->connection->log;
     rctx->file.fd = ngx_open_file(path.data, mode, create_mode,
-                                  NGX_FILE_DEFAULT_ACCESS);
+                                  cscf->file_access);
     ngx_str_set(&rctx->file.name, "recorded");
 
     if (rctx->file.fd == NGX_INVALID_FILE) {


### PR DESCRIPTION
This adds a new directive, file_access, allowing the default directory and file permissions to be overridden. E.g. file_access user:rw group:rw all:r;
It's also worth noting that this changes the default directory create mode for hls/dash from 0744 to 0755.
