### PR TITLE
Update ngx_rtmp_live_module.c

### DIFF
--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -178,7 +178,7 @@ ngx_rtmp_live_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_msec_value(conf->sync, prev->sync, 300);
     ngx_conf_merge_msec_value(conf->idle_timeout, prev->idle_timeout, 0);
     ngx_conf_merge_value(conf->interleave, prev->interleave, 0);
-    ngx_conf_merge_value(conf->wait_key, prev->wait_key, 1);
+    ngx_conf_merge_value(conf->wait_key, prev->wait_key, 0);
     ngx_conf_merge_value(conf->wait_video, prev->wait_video, 0);
     ngx_conf_merge_value(conf->publish_notify, prev->publish_notify, 0);
     ngx_conf_merge_value(conf->play_restart, prev->play_restart, 0);


### PR DESCRIPTION
The codes run counter to what describled in wiki manual about wait_key. "Makes video stream start with a key frame. Defaults to off.", Wiki manual says.
