### PR TITLE
Remove unneeded space in EXT-X-PLAYLIST-TYPE tag

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -528,7 +528,7 @@ ngx_rtmp_hls_write_playlist(ngx_rtmp_session_t *s)
                      ctx->frag, max_frag);
 
     if (hacf->type == NGX_RTMP_HLS_TYPE_EVENT) {
-        p = ngx_slprintf(p, end, "#EXT-X-PLAYLIST-TYPE: EVENT\n");
+        p = ngx_slprintf(p, end, "#EXT-X-PLAYLIST-TYPE:EVENT\n");
     }
 
     n = ngx_write_fd(fd, buffer, p - buffer);


### PR DESCRIPTION
When running [mediastreamvalidator](https://developer.apple.com/library/ios/technotes/tn2235/_index.html) on hls playlists of type event a warning is generated:

```
Playlist Syntax:

	Warning: (0:-12264) Unneeded space in line
	--> #EXT-X-PLAYLIST-TYPE: EVENT
```

I've removed the unneeded space. 
