### PR TITLE
Add output of client connection port

### DIFF
--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -329,6 +329,7 @@ ngx_rtmp_stat_client(ngx_http_request_t *r, ngx_chain_t ***lll,
     ngx_rtmp_session_t *s)
 {
     u_char  buf[NGX_INT_T_LEN];
+    struct sockaddr_in *sa;
 
 #ifdef NGX_RTMP_POOL_DEBUG
     ngx_rtmp_stat_dump_pool(r, lll, s->connection->pool);
@@ -341,6 +342,12 @@ ngx_rtmp_stat_client(ngx_http_request_t *r, ngx_chain_t ***lll,
     NGX_RTMP_STAT_L("<address>");
     NGX_RTMP_STAT_ES(&s->connection->addr_text);
     NGX_RTMP_STAT_L("</address>");
+
+    NGX_RTMP_STAT_L("<port>");
+    sa = (struct sockaddr_in *) s->connection->sockaddr;
+    NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%ui",
+                  (ngx_uint_t) ntohs(sa->sin_port)) - buf);
+    NGX_RTMP_STAT_L("</port>");
 
     NGX_RTMP_STAT_L("<time>");
     NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf), "%i",

--- a/stat.xsl
+++ b/stat.xsl
@@ -316,7 +316,7 @@
                     http://apps.db.ripe.net/search/query.html&#63;searchtext=<xsl:value-of select="address"/>
                 </xsl:attribute>
                 <xsl:attribute name="title">whois</xsl:attribute>
-                <xsl:value-of select="address"/>
+                <xsl:value-of select="address"/>:<xsl:value-of select="port"/>
             </a>
         </td>
         <td><xsl:value-of select="flashver"/></td>


### PR DESCRIPTION
Based on https://github.com/arut/nginx-rtmp-module/pull/634 but doing it right way.
Output to statistics xml client connection port, not server listening port.