### PR TITLE
Support record_interval option for manual recording and allow to stop auto recording

### DIFF
--- a/config
+++ b/config
@@ -20,6 +20,7 @@ CORE_MODULES="$CORE_MODULES
                 ngx_rtmp_limit_module                       \
                 ngx_rtmp_hls_module                         \
                 ngx_rtmp_dash_module                        \
+                ngx_rtmp_ssl_module                         \
                 "
 
 
@@ -47,6 +48,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS                             \
                 $ngx_addon_dir/ngx_rtmp_proxy_protocol.h    \
                 $ngx_addon_dir/hls/ngx_rtmp_mpegts.h        \
                 $ngx_addon_dir/dash/ngx_rtmp_mp4.h          \
+                $ngx_addon_dir/ngx_rtmp_ssl_module.h        \
                 "
 
 
@@ -85,6 +87,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS                             \
                 $ngx_addon_dir/dash/ngx_rtmp_dash_module.c  \
                 $ngx_addon_dir/hls/ngx_rtmp_mpegts.c        \
                 $ngx_addon_dir/dash/ngx_rtmp_mp4.c          \
+                $ngx_addon_dir/ngx_rtmp_ssl_module.c        \
                 "
 CFLAGS="$CFLAGS -I$ngx_addon_dir"
 

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -85,7 +85,7 @@ typedef struct {
     ngx_flag_t                          nested;
     ngx_str_t                           path;
     ngx_uint_t                          winfrags;
-    ngx_flag_t                          cleanup;
+    ngx_msec_t                          cleanup;
     ngx_path_t                         *slot;
 } ngx_rtmp_dash_app_conf_t;
 
@@ -122,7 +122,7 @@ static ngx_command_t ngx_rtmp_dash_commands[] = {
 
     { ngx_string("dash_cleanup"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
+      ngx_conf_set_msec_slot,
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_dash_app_conf_t, cleanup),
       NULL },
@@ -1437,7 +1437,7 @@ ngx_rtmp_dash_create_app_conf(ngx_conf_t *cf)
     conf->dash = NGX_CONF_UNSET;
     conf->fraglen = NGX_CONF_UNSET_MSEC;
     conf->playlen = NGX_CONF_UNSET_MSEC;
-    conf->cleanup = NGX_CONF_UNSET;
+    conf->cleanup = NGX_CONF_UNSET_MSEC;
     conf->nested = NGX_CONF_UNSET;
 
     return conf;
@@ -1454,7 +1454,7 @@ ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->dash, prev->dash, 0);
     ngx_conf_merge_msec_value(conf->fraglen, prev->fraglen, 5000);
     ngx_conf_merge_msec_value(conf->playlen, prev->playlen, 30000);
-    ngx_conf_merge_value(conf->cleanup, prev->cleanup, 1);
+    ngx_conf_merge_msec_value(conf->cleanup, prev->cleanup, conf->playlen);
     ngx_conf_merge_value(conf->nested, prev->nested, 0);
 
     if (conf->fraglen) {
@@ -1474,7 +1474,7 @@ ngx_rtmp_dash_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
         }
 
         cleanup->path = conf->path;
-        cleanup->playlen = conf->playlen;
+        cleanup->playlen = conf->cleanup;
 
         conf->slot = ngx_pcalloc(cf->pool, sizeof(*conf->slot));
         if (conf->slot == NULL) {

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -97,6 +97,7 @@ typedef struct {
     ngx_msec_t                          sync;
     ngx_msec_t                          playlen;
     ngx_uint_t                          winfrags;
+    ngx_uint_t                          max_fragsize;
     ngx_flag_t                          continuous;
     ngx_flag_t                          nested;
     ngx_str_t                           path;
@@ -1580,9 +1581,25 @@ ngx_rtmp_hls_update_fragment(ngx_rtmp_session_t *s, uint64_t ts,
         f = ngx_rtmp_hls_get_frag(s, ctx->nfrags);
         d = (int64_t) (ts - ctx->frag_ts);
 
-        if (d > (int64_t) hacf->max_fraglen * 90 || d < -90000) {
+        if (ctx->file.fsize >= hacf->max_fragsize) {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                          "hls: force fragment split: %.3f sec, ", d / 90000.);
+                          "hls: force fragment split: %d bytes",
+                          ctx->file.fsize);
+            force = 1;
+
+        } else if (boundary == 2 && d > (int64_t) hacf->max_fraglen * 45) {
+            /*
+             * Video key frame but no audio is buffered.
+             * Force on 1/2 of max_fraglen
+             */
+            ngx_log_error(NGX_LOG_WARN, s->connection->log, 0,
+                          "hls: force fragment split on boundary: %.3f sec",
+                          d / 90000.);
+            force = 1;
+
+        } else if (d > (int64_t) hacf->max_fraglen * 90 || d < -90000) {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                          "hls: force fragment split: %.3f sec", d / 90000.);
             force = 1;
 
         } else {
@@ -1687,7 +1704,7 @@ ngx_rtmp_hls_audio(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     size_t                          bsize;
     ngx_buf_t                      *b;
     u_char                         *p;
-    ngx_uint_t                      objtype, srindex, chconf, size;
+    ngx_uint_t                      objtype, srindex, chconf, size, no_video;
 
     hacf = ngx_rtmp_get_module_app_conf(s, ngx_rtmp_hls_module);
 
@@ -1740,9 +1757,13 @@ ngx_rtmp_hls_audio(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
      * start new fragment here if
      * there's no video at all, otherwise
      * do it in video handler
+     *
+     * audio and video may come out of sync
+     * use only one stream ts for the fragment update
+     * video if available or audio
      */
-
-    ngx_rtmp_hls_update_fragment(s, pts, codec_ctx->avc_header == NULL, 2);
+    no_video = codec_ctx->avc_header == NULL;
+    ngx_rtmp_hls_update_fragment(s, no_video ? pts : ctx->frag_ts, no_video, 2);
 
     if (b->last + size > b->end) {
         ngx_rtmp_hls_flush_audio(s);
@@ -2020,11 +2041,16 @@ ngx_rtmp_hls_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
      * start new fragment if
      * - we have video key frame AND
      * - we have audio buffered or have no audio at all or stream is closed
+     * - set boundary to 2 if only the 1st condition is met
      */
 
     b = ctx->aframe;
-    boundary = frame.key && (codec_ctx->aac_header == NULL || !ctx->opened ||
-                             (b && b->last > b->pos));
+    if (frame.key) {
+        boundary = (codec_ctx->aac_header == NULL || !ctx->opened ||
+                    (b && b->last > b->pos)) ? 1 : 2;
+    } else {
+        boundary = 0;
+    }
 
     ngx_rtmp_hls_update_fragment(s, frame.dts, boundary, 1);
 
@@ -2286,6 +2312,7 @@ ngx_rtmp_hls_create_app_conf(ngx_conf_t *cf)
     conf->hls = NGX_CONF_UNSET;
     conf->fraglen = NGX_CONF_UNSET_MSEC;
     conf->max_fraglen = NGX_CONF_UNSET_MSEC;
+    conf->max_fragsize = NGX_CONF_UNSET_UINT;
     conf->muxdelay = NGX_CONF_UNSET_MSEC;
     conf->sync = NGX_CONF_UNSET_MSEC;
     conf->playlen = NGX_CONF_UNSET_MSEC;
@@ -2316,6 +2343,8 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_msec_value(conf->fraglen, prev->fraglen, 5000);
     ngx_conf_merge_msec_value(conf->max_fraglen, prev->max_fraglen,
                               conf->fraglen * 10);
+    ngx_conf_merge_msec_value(conf->max_fragsize, prev->max_fragsize,
+                              16*1024*1024); /*16Mb*/
     ngx_conf_merge_msec_value(conf->muxdelay, prev->muxdelay, 700);
     ngx_conf_merge_msec_value(conf->sync, prev->sync, 2);
     ngx_conf_merge_msec_value(conf->playlen, prev->playlen, 30000);

--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -107,7 +107,7 @@ typedef struct {
     ngx_path_t                         *slot;
     ngx_msec_t                          max_audio_delay;
     size_t                              audio_buffer_size;
-    ngx_flag_t                          cleanup;
+    ngx_msec_t                          cleanup;
     ngx_array_t                        *variant;
     ngx_str_t                           base_url;
     ngx_int_t                           granularity;
@@ -255,7 +255,7 @@ static ngx_command_t ngx_rtmp_hls_commands[] = {
 
     { ngx_string("hls_cleanup"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_flag_slot,
+      ngx_conf_set_msec_slot,
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_hls_app_conf_t, cleanup),
       NULL },
@@ -2323,7 +2323,7 @@ ngx_rtmp_hls_create_app_conf(ngx_conf_t *cf)
     conf->type = NGX_CONF_UNSET_UINT;
     conf->max_audio_delay = NGX_CONF_UNSET_MSEC;
     conf->audio_buffer_size = NGX_CONF_UNSET_SIZE;
-    conf->cleanup = NGX_CONF_UNSET;
+    conf->cleanup = NGX_CONF_UNSET_MSEC;
     conf->granularity = NGX_CONF_UNSET;
     conf->keys = NGX_CONF_UNSET;
     conf->frags_per_key = NGX_CONF_UNSET_UINT;
@@ -2360,7 +2360,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
                               300);
     ngx_conf_merge_size_value(conf->audio_buffer_size, prev->audio_buffer_size,
                               NGX_RTMP_HLS_BUFSIZE);
-    ngx_conf_merge_value(conf->cleanup, prev->cleanup, 1);
+    ngx_conf_merge_msec_value(conf->cleanup, prev->cleanup, conf->playlen);
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);
@@ -2387,7 +2387,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
         }
 
         cleanup->path = conf->path;
-        cleanup->playlen = conf->playlen;
+        cleanup->playlen = conf->cleanup;
 
         conf->slot = ngx_pcalloc(cf->pool, sizeof(*conf->slot));
         if (conf->slot == NULL) {
@@ -2421,7 +2421,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
         }
 
         cleanup->path = conf->key_path;
-        cleanup->playlen = conf->playlen;
+        cleanup->playlen = conf->cleanup;
 
         conf->slot = ngx_pcalloc(cf->pool, sizeof(*conf->slot));
         if (conf->slot == NULL) {

--- a/hls/ngx_rtmp_mpegts.c
+++ b/hls/ngx_rtmp_mpegts.c
@@ -89,6 +89,7 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, file->log, 0,
                        "mpegts: write %uz bytes", in_size);
 
+        file->fsize += in_size;
         rc = ngx_write_fd(file->fd, in, in_size);
         if (rc < 0) {
             return NGX_ERROR;
@@ -136,6 +137,7 @@ ngx_rtmp_mpegts_write_file(ngx_rtmp_mpegts_file_t *file, u_char *in,
             break;
         }
 
+        file->fsize += out - buf + n;
         rc = ngx_write_fd(file->fd, buf, out - buf + n);
         if (rc < 0) {
             return NGX_ERROR;
@@ -364,6 +366,7 @@ ngx_rtmp_mpegts_open_file(ngx_rtmp_mpegts_file_t *file, u_char *path,
     }
 
     file->size = 0;
+    file->fsize = 0;
 
     if (ngx_rtmp_mpegts_write_header(file) != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, log, ngx_errno,

--- a/hls/ngx_rtmp_mpegts.h
+++ b/hls/ngx_rtmp_mpegts.h
@@ -21,6 +21,7 @@ typedef struct {
     u_char      buf[16];
     u_char      iv[16];
     AES_KEY     key;
+    ngx_uint_t  fsize;
 } ngx_rtmp_mpegts_file_t;
 
 

--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -552,6 +552,7 @@ found:
     addr->wildcard = listen->wildcard;
     addr->so_keepalive = listen->so_keepalive;
     addr->proxy_protocol = listen->proxy_protocol;
+    addr->ssl = listen->ssl;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
     addr->tcp_keepidle = listen->tcp_keepidle;
     addr->tcp_keepintvl = listen->tcp_keepintvl;
@@ -711,6 +712,7 @@ ngx_rtmp_add_addrs(ngx_conf_t *cf, ngx_rtmp_port_t *mport,
         addrs[i].conf.addr_text.len = len;
         addrs[i].conf.addr_text.data = p;
         addrs[i].conf.proxy_protocol = addr->proxy_protocol;
+        addrs[i].conf.ssl = addr->ssl;
     }
 
     return NGX_OK;

--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -32,7 +32,9 @@ static char * ngx_rtmp_merge_applications(ngx_conf_t *cf,
 static ngx_int_t ngx_rtmp_init_process(ngx_cycle_t *cycle);
 
 
-#if (nginx_version >= 1007005)
+#if (nginx_version >= 1007011)
+ngx_queue_t                         ngx_rtmp_init_queue;
+#elif (nginx_version >= 1007005)
 ngx_thread_volatile ngx_queue_t     ngx_rtmp_init_queue;
 #else
 ngx_thread_volatile ngx_event_t    *ngx_rtmp_init_queue;

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -45,6 +45,7 @@ typedef struct {
 #endif
     unsigned                so_keepalive:2;
     unsigned                proxy_protocol:1;
+    unsigned                ssl:1;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
     int                     tcp_keepidle;
     int                     tcp_keepintvl;
@@ -57,6 +58,7 @@ typedef struct {
     ngx_rtmp_conf_ctx_t    *ctx;
     ngx_str_t               addr_text;
     unsigned                proxy_protocol:1;
+    unsigned                ssl:1;
 } ngx_rtmp_addr_conf_t;
 
 typedef struct {
@@ -101,6 +103,7 @@ typedef struct {
 #endif
     unsigned                so_keepalive:2;
     unsigned                proxy_protocol:1;
+    unsigned                ssl:1;
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
     int                     tcp_keepidle;
     int                     tcp_keepintvl;
@@ -240,6 +243,9 @@ typedef struct {
     unsigned                auto_pushed:1;
     unsigned                relay:1;
     unsigned                static_relay:1;
+
+    /* RTMPS */
+    unsigned                ssl:1;
 
     /* input stream 0 (reserved by RTMP spec)
      * is used as free chain link */

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -607,7 +607,9 @@ extern ngx_rtmp_bandwidth_t                 ngx_rtmp_bw_in;
 
 
 extern ngx_uint_t                           ngx_rtmp_naccepted;
-#if (nginx_version >= 1007005)
+#if (nginx_version >= 1007011)
+extern ngx_queue_t                          ngx_rtmp_init_queue;
+#elif (nginx_version >= 1007005)
 extern ngx_thread_volatile ngx_queue_t      ngx_rtmp_init_queue;
 #else
 extern ngx_thread_volatile ngx_event_t     *ngx_rtmp_init_queue;

--- a/ngx_rtmp.h
+++ b/ngx_rtmp.h
@@ -247,6 +247,9 @@ typedef struct {
     /* RTMPS */
     unsigned                ssl:1;
 
+    /* always send args */
+    unsigned                send_args:1;
+
     /* input stream 0 (reserved by RTMP spec)
      * is used as free chain link */
 
@@ -530,6 +533,12 @@ ngx_int_t ngx_rtmp_send_ack_size(ngx_rtmp_session_t *s,
         uint32_t ack_size);
 ngx_int_t ngx_rtmp_send_bandwidth(ngx_rtmp_session_t *s,
         uint32_t ack_size, uint8_t limit_type);
+
+/* Connection error messages */
+ngx_chain_t* ngx_rtmp_create_connection_error(ngx_rtmp_session_t *s,
+        double trans, char *desc);
+ngx_int_t ngx_rtmp_send_connection_error(ngx_rtmp_session_t *s,
+        double trans, char *desc);
 
 /* User control messages */
 ngx_chain_t * ngx_rtmp_create_stream_begin(ngx_rtmp_session_t *s,

--- a/ngx_rtmp_cmd_module.c
+++ b/ngx_rtmp_cmd_module.c
@@ -271,6 +271,15 @@ ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
     h.csid = NGX_RTMP_CSID_AMF_INI;
     h.type = NGX_RTMP_MSG_AMF_CMD;
 
+    /* in case of redirect new arguments set could be specified
+     * store them to pass to every event request
+     */
+    p = (u_char *)ngx_strchr(v->app, '?');
+    if (p) {
+        *p++ = 0;
+        ngx_cpystrn(v->args, p, NGX_RTMP_MAX_ARGS);
+        s->send_args = 1;
+    }
 
 #define NGX_RTMP_SET_STRPAR(name)                                             \
     s->name.len = ngx_strlen(v->name);                                        \
@@ -285,11 +294,6 @@ ngx_rtmp_cmd_connect(ngx_rtmp_session_t *s, ngx_rtmp_connect_t *v)
     NGX_RTMP_SET_STRPAR(page_url);
 
 #undef NGX_RTMP_SET_STRPAR
-
-    p = ngx_strlchr(s->app.data, s->app.data + s->app.len, '?');
-    if (p) {
-        s->app.len = (p - s->app.data);
-    }
 
     s->acodecs = (uint32_t) v->acodecs;
     s->vcodecs = (uint32_t) v->vcodecs;

--- a/ngx_rtmp_core_module.c
+++ b/ngx_rtmp_core_module.c
@@ -9,6 +9,7 @@
 #include <ngx_event.h>
 #include <nginx.h>
 #include "ngx_rtmp.h"
+#include "ngx_rtmp_ssl_module.h"
 
 
 static void *ngx_rtmp_core_create_main_conf(ngx_conf_t *cf);
@@ -45,7 +46,7 @@ static ngx_command_t  ngx_rtmp_core_commands[] = {
       NULL },
 
     { ngx_string("listen"),
-      NGX_RTMP_SRV_CONF|NGX_CONF_TAKE12,
+      NGX_RTMP_SRV_CONF|NGX_CONF_TAKE123,
       ngx_rtmp_core_listen,
       NGX_RTMP_SRV_CONF_OFFSET,
       0,
@@ -721,6 +722,14 @@ ngx_rtmp_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
         if (ngx_strcmp(value[i].data, "proxy_protocol") == 0) {
             ls->proxy_protocol = 1;
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "rtmps") == 0) {
+            if (ngx_rtmp_ssl_enable(cf) != NGX_OK) {
+                return NGX_CONF_ERROR;
+            }
+            ls->ssl = 1;
             continue;
         }
 

--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -8,6 +8,7 @@
 #include <ngx_core.h>
 #include "ngx_rtmp.h"
 #include "ngx_rtmp_proxy_protocol.h"
+#include "ngx_rtmp_ssl_module.h"
 
 
 static void ngx_rtmp_close_connection(ngx_connection_t *c);
@@ -133,7 +134,8 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
     if (addr_conf->proxy_protocol) {
         ngx_rtmp_proxy_protocol(s);
-
+    } else if (s->ssl) {
+        ngx_rtmp_ssl_handshake(s);
     } else {
         ngx_rtmp_handshake(s);
     }
@@ -160,6 +162,8 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
     s->srv_conf = addr_conf->ctx->srv_conf;
 
     s->addr_text = &addr_conf->addr_text;
+
+    s->ssl = addr_conf->ssl;
 
     c->data = s;
     s->connection = c;
@@ -255,6 +259,13 @@ ngx_rtmp_close_connection(ngx_connection_t *c)
     ngx_pool_t                         *pool;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, c->log, 0, "close connection");
+
+    if (c->ssl) {
+        if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+            c->ssl->handler = ngx_rtmp_close_connection;
+            return;
+        }
+    }
 
 #if (NGX_STAT_STUB)
     (void) ngx_atomic_fetch_add(ngx_stat_active, -1);

--- a/ngx_rtmp_netcall_module.c
+++ b/ngx_rtmp_netcall_module.c
@@ -586,7 +586,8 @@ ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
             sizeof("&tcurl=") - 1 + s->tc_url.len * 3 +
             sizeof("&pageurl=") - 1 + s->page_url.len * 3 +
             sizeof("&addr=") - 1 + addr_text->len * 3 +
-            sizeof("&clientid=") - 1 + NGX_INT_T_LEN
+            sizeof("&clientid=") - 1 + NGX_INT_T_LEN +
+            (s->send_args ? (s->args.len + 1) : 0)
         );
 
     if (b == NULL) {
@@ -627,6 +628,11 @@ ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
     b->last = ngx_cpymem(b->last, (u_char*) "&clientid=",
                          sizeof("&clientid=") - 1);
     b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->connection->number);
+
+    if (s->send_args) {
+        *b->last++ = '&';
+        b->last = ngx_cpymem(b->last, s->args.data, s->args.len);
+    }
 
     return cl;
 }

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -991,9 +991,16 @@ ngx_rtmp_notify_connect_handle(ngx_rtmp_session_t *s,
     u_char              app[NGX_RTMP_MAX_NAME];
 
     static ngx_str_t    location = ngx_string("location");
+    static ngx_str_t    error_description = ngx_string("RTMP-description");
 
     rc = ngx_rtmp_notify_parse_http_retcode(s, in);
     if (rc == NGX_ERROR) {
+        rc = ngx_rtmp_notify_parse_http_header(s, in, &error_description, 
+                                            app, sizeof(app) - 1);
+        if (rc > 0) {
+            app[rc] = 0;
+            ngx_rtmp_send_connection_error(s, v->trans, (char*)app);
+        }
         return NGX_ERROR;
     }
 

--- a/ngx_rtmp_proxy_protocol.c
+++ b/ngx_rtmp_proxy_protocol.c
@@ -8,6 +8,7 @@
 #include <ngx_core.h>
 #include <nginx.h>
 #include "ngx_rtmp_proxy_protocol.h"
+#include "ngx_rtmp_ssl_module.h"
 
 
 static void ngx_rtmp_proxy_protocol_recv(ngx_event_t *rev);
@@ -183,7 +184,11 @@ skip:
                        "proxy_protocol: remote_addr:'%V'", &c->addr_text);
     }
 
-    ngx_rtmp_handshake(s);
+    if (s->ssl) {
+        ngx_rtmp_ssl_handshake(s);
+    } else {
+        ngx_rtmp_handshake(s);
+    }
 
     return;
 

--- a/ngx_rtmp_record_module.c
+++ b/ngx_rtmp_record_module.c
@@ -302,7 +302,7 @@ ngx_rtmp_record_open(ngx_rtmp_session_t *s, ngx_uint_t n, ngx_str_t *path)
     }
 
     rc = ngx_rtmp_record_node_open(s, rctx);
-    if (rc != NGX_OK) {
+    if (rc != NGX_OK && rc != NGX_AGAIN) {
         return rc;
     }
 

--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -53,6 +53,7 @@ typedef struct {
     unsigned                            video_key_sent:1;
     unsigned                            audio:1;
     unsigned                            video:1;
+    unsigned                            started:1;
 } ngx_rtmp_record_rec_ctx_t;
 
 

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1335,7 +1335,6 @@ ngx_rtmp_relay_close(ngx_rtmp_session_t *s)
 
     if (s->static_relay) {
         ngx_add_timer(ctx->static_evt, racf->pull_reconnect);
-        return;
     }
 
     if (ctx->publish == NULL) {

--- a/ngx_rtmp_ssl_module.c
+++ b/ngx_rtmp_ssl_module.c
@@ -1,0 +1,323 @@
+
+/*
+ * RTMPS supporting module
+ * Copyright (C) Ilya Panfilov
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+#include "ngx_rtmp_ssl_module.h"
+
+#define NGX_RTMPS_DEFAULT_CIPHERS       "HIGH:MEDIUM:!aNULL:!eNULL"
+#define NGX_RTMPS_DEFAULT_ECDH_CURVE    "prime256v1"
+#define NGX_RTMPS_DEFAULT_PROTOCOLS     NGX_SSL_SSLv2 \
+                                        | NGX_SSL_SSLv3 \
+                                        | NGX_SSL_TLSv1 \
+                                        | NGX_SSL_TLSv1_1 \
+                                        | NGX_SSL_TLSv1_2
+
+
+static void *ngx_rtmp_ssl_create_srv_conf(ngx_conf_t *cf);
+static char *ngx_rtmp_ssl_merge_srv_conf(ngx_conf_t *cf,
+    void *parent, void *child);
+
+void ngx_rtmp_ssl_handshake(ngx_rtmp_session_t *s);
+static void ngx_rtmp_ssl_handshake_handler(ngx_connection_t *c);
+
+
+static ngx_conf_bitmask_t  ngx_rtmp_ssl_protocols[] = {
+    { ngx_string("SSLv2"), NGX_SSL_SSLv2 },
+    { ngx_string("SSLv3"), NGX_SSL_SSLv3 },
+    { ngx_string("TLSv1"), NGX_SSL_TLSv1 },
+    { ngx_string("TLSv1.1"), NGX_SSL_TLSv1_1 },
+    { ngx_string("TLSv1.2"), NGX_SSL_TLSv1_2 },
+    { ngx_null_string, 0 }
+};
+
+
+static ngx_command_t  ngx_rtmp_ssl_commands[] = {
+    { ngx_string("ssl_protocols"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_1MORE,
+      ngx_conf_set_bitmask_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, protocols),
+      &ngx_rtmp_ssl_protocols },
+
+    { ngx_string("ssl_certificate"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, certificate),
+      NULL },
+
+    { ngx_string("ssl_certificate_key"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, certificate_key),
+      NULL },
+
+    { ngx_string("ssl_password_file"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, password_file),
+      NULL },
+
+    { ngx_string("ssl_ciphers"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, ciphers),
+      NULL },
+
+    { ngx_string("ssl_prefer_server_ciphers"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, prefer_server_ciphers),
+      NULL },
+
+    { ngx_string("ssl_dhparam"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, dhparam),
+      NULL },
+
+    { ngx_string("ssl_ecdh_curve"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_RTMP_SRV_CONF_OFFSET,
+      offsetof(ngx_rtmp_ssl_srv_conf_t, ecdh_curve),
+      NULL },
+
+    ngx_null_command
+};
+
+
+static ngx_rtmp_module_t  ngx_rtmp_ssl_module_ctx = {
+    NULL,                                   /* preconfiguration */
+    NULL,                                   /* postconfiguration */
+    NULL,                                   /* create main configuration */
+    NULL,                                   /* init main configuration */
+    ngx_rtmp_ssl_create_srv_conf,           /* create server configuration */
+    ngx_rtmp_ssl_merge_srv_conf,            /* merge server configuration */
+    NULL,                                   /* create app configuration */
+    NULL                                    /* merge app configuration */
+};
+
+
+ngx_module_t  ngx_rtmp_ssl_module = {
+    NGX_MODULE_V1,
+    &ngx_rtmp_ssl_module_ctx,             /* module context */
+    ngx_rtmp_ssl_commands,                /* module directives */
+    NGX_RTMP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+ngx_int_t
+ngx_rtmp_ssl_enable(ngx_conf_t *cf)
+{
+    ngx_rtmp_ssl_srv_conf_t *sscf;
+
+    sscf = ngx_rtmp_conf_get_module_srv_conf(cf, ngx_rtmp_ssl_module);
+    sscf->enable = 1;
+
+    return NGX_OK;
+}
+
+
+static void *
+ngx_rtmp_ssl_create_srv_conf(ngx_conf_t *cf)
+{
+    ngx_rtmp_ssl_srv_conf_t *sscf;
+
+    sscf = ngx_pcalloc(cf->pool, sizeof(ngx_rtmp_ssl_srv_conf_t));
+    if (sscf == NULL) {
+        return NULL;
+    }
+
+    sscf->prefer_server_ciphers = NGX_CONF_UNSET;
+
+    return sscf;
+}
+
+
+static char *
+ngx_rtmp_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_rtmp_ssl_srv_conf_t *prev = parent;
+    ngx_rtmp_ssl_srv_conf_t *conf = child;
+
+    ngx_pool_cleanup_t  *cln;
+    ngx_array_t         *passwords = NULL;
+
+    conf->ssl.log = cf->log;
+
+    if (!conf->enable) {
+        return NGX_CONF_OK;
+    }
+
+    ngx_conf_merge_str_value(conf->certificate, prev->certificate, "");
+    if (conf->certificate.len == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "Missing ssl_certificate");
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_conf_merge_str_value(conf->certificate_key, prev->certificate_key, "");
+    if (conf->certificate_key.len == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "Missing ssl_certificate_key");
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_conf_merge_bitmask_value(conf->protocols, prev->protocols,
+                                 NGX_CONF_BITMASK_SET
+                                 |NGX_RTMPS_DEFAULT_PROTOCOLS);
+
+    ngx_conf_merge_str_value(conf->password_file, prev->password_file, "");
+
+    ngx_conf_merge_str_value(conf->dhparam, prev->dhparam, "");
+
+    ngx_conf_merge_str_value(conf->ecdh_curve, prev->ecdh_curve,
+                             NGX_RTMPS_DEFAULT_ECDH_CURVE);
+
+    ngx_conf_merge_str_value(conf->ciphers, prev->ciphers,
+                             NGX_RTMPS_DEFAULT_CIPHERS);
+
+    ngx_conf_merge_value(conf->prefer_server_ciphers,
+                         prev->prefer_server_ciphers, 0);
+
+    if (ngx_ssl_create(&conf->ssl, conf->protocols, conf) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    cln->handler = ngx_ssl_cleanup_ctx;
+    cln->data = &conf->ssl;
+
+    if (conf->password_file.len > 0) {
+        passwords = ngx_ssl_read_password_file(cf, &conf->password_file);
+        if (passwords == NULL) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (ngx_ssl_certificate(cf, &conf->ssl, &conf->certificate,
+                            &conf->certificate_key, passwords)
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+
+    if (SSL_CTX_set_cipher_list(conf->ssl.ctx,
+                                (const char *) conf->ciphers.data)
+        == 0)
+    {
+        ngx_ssl_error(NGX_LOG_EMERG, cf->log, 0,
+                      "SSL_CTX_set_cipher_list(%V) failed", &conf->ciphers);
+        return NGX_CONF_ERROR;
+    }
+
+    if (conf->prefer_server_ciphers) {
+        SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    }
+
+    if (ngx_ssl_dhparam(cf, &conf->ssl, &conf->dhparam) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_ecdh_curve(cf, &conf->ssl, &conf->ecdh_curve) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
+
+    return NGX_CONF_OK;
+}
+
+
+void
+ngx_rtmp_ssl_handshake(ngx_rtmp_session_t *s)
+{
+    ngx_connection_t  *c;
+    ngx_rtmp_ssl_srv_conf_t       *sscf;
+
+    c = s->connection;
+
+    sscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_ssl_module);
+
+    if (ngx_ssl_create_connection(&sscf->ssl, c, 0) != NGX_OK)
+    {
+        ngx_rtmp_finalize_session(s);
+        return;
+    }
+
+    ngx_rtmp_ssl_handshake_handler(c);
+    return;
+}
+
+
+static void
+ngx_rtmp_ssl_handshake_handler(ngx_connection_t *c)
+{
+    ngx_rtmp_session_t *s;
+    ngx_event_t        *rev;
+    ngx_int_t          rc;
+
+    s = c->data;
+
+    if (c->ssl->handshaked) {
+        ngx_rtmp_handshake(s);
+        return;
+    }
+
+    if (c->read->timedout) {
+        ngx_log_error(NGX_LOG_INFO, c->log, NGX_ETIMEDOUT, "SSL handshake timed out");
+        ngx_rtmp_finalize_session(s);
+        return;
+    }
+
+    if (c->read->error || c->write->error || c->error) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0, "SSL handshake failed: c%d w%d r%d",
+        c->error, c->write->error, c->read->error);
+        ngx_rtmp_finalize_session(s);
+        return;
+    }
+
+    rc = ngx_ssl_handshake(c);
+
+    if (rc == NGX_AGAIN) {
+
+        rev = c->read;
+
+        if (!rev->timer_set) {
+            ngx_add_timer(rev, s->timeout);
+        }
+
+        c->ssl->handler = ngx_rtmp_ssl_handshake_handler;
+        return;
+    }
+
+    if (rc == NGX_OK) {
+        ngx_rtmp_handshake(s);
+        return;
+    }
+
+    ngx_rtmp_finalize_session(s);
+    return;
+}

--- a/ngx_rtmp_ssl_module.h
+++ b/ngx_rtmp_ssl_module.h
@@ -1,0 +1,36 @@
+
+/*
+ * RTMPS supporting module
+ * Copyright (C) Ilya Panfilov
+ */
+
+#ifndef _NGX_RTMP_SSL_MODULE_H_
+#define _NGX_RTMP_SSL_MODULE_H_
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include "ngx_rtmp.h"
+
+typedef struct {
+    ngx_flag_t                      enable;
+
+    ngx_ssl_t                       ssl;
+
+    ngx_uint_t                      protocols;
+
+    ngx_str_t                       certificate;
+    ngx_str_t                       certificate_key;
+    ngx_str_t                       password_file;
+
+    ngx_str_t                       ciphers;
+    ngx_flag_t                      prefer_server_ciphers;
+
+    ngx_str_t                       dhparam;
+    ngx_str_t                       ecdh_curve;
+} ngx_rtmp_ssl_srv_conf_t;
+
+ngx_int_t ngx_rtmp_ssl_enable(ngx_conf_t *cf);
+void ngx_rtmp_ssl_handshake(ngx_rtmp_session_t *c);
+
+
+#endif /* _NGX_RTMP_SSL_MODULE_H_ */


### PR DESCRIPTION
The chahnge has two effects:
- Honor record_interval option for manual recording in the same way as for auto
- Allow to stop auto recording;
  <br>With record_interval set the only difference between auto and manual recordings is automatic or manual start
  <br>Without record_interval set auto recording restarts file based on record_max_[size|frames] until stopped. Manual recording in such config runs once
