### PR TITLE
for some condition sps/pps is embedded in the h264 stream, use these …

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -1936,10 +1936,13 @@ ngx_rtmp_hls_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                        (ngx_uint_t) nal_type, len);
 
         if (nal_type >= 7 && nal_type <= 9) {
+            sps_pps_sent = 1;
+/*
             if (ngx_rtmp_hls_copy(s, NULL, &p, len - 1, &in) != NGX_OK) {
                 return NGX_ERROR;
             }
             continue;
+*/
         }
 
         if (!aud_sent) {


### PR DESCRIPTION
…sps/pps instead of the global sps/pps. Because in some condition, the global sps/pps is wrong