### PR TITLE
Store audio and video bitrate in variables of type double

### DIFF
--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -858,9 +858,9 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     ctx->height = (ngx_uint_t) v.height;
     ctx->duration = (ngx_uint_t) v.duration;
     ctx->frame_rate = (ngx_uint_t) v.frame_rate;
-    ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
+    ctx->video_data_rate = v.video_data_rate;
     ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
-    ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
+    ctx->audio_data_rate = v.audio_data_rate;
     ctx->audio_codec_id = (v.audio_codec_id_n == -1
             ? 0 : v.audio_codec_id_n == 0
             ? NGX_RTMP_AUDIO_UNCOMPRESSED : (ngx_uint_t) v.audio_codec_id_n);

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -54,9 +54,9 @@ typedef struct {
     ngx_uint_t                  height;
     ngx_uint_t                  duration;
     ngx_uint_t                  frame_rate;
-    ngx_uint_t                  video_data_rate;
+    double                      video_data_rate;
     ngx_uint_t                  video_codec_id;
-    ngx_uint_t                  audio_data_rate;
+    double                      audio_data_rate;
     ngx_uint_t                  audio_codec_id;
     ngx_uint_t                  aac_profile;
     ngx_uint_t                  aac_chan_conf;


### PR DESCRIPTION
Bitrate's fraction part is lost when casting to integer type, so it should be stored in double.