### PR TITLE
Add "record_align_interval" option

### DIFF
--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -36,6 +36,7 @@ typedef struct {
 
     void                              **rec_conf;
     ngx_array_t                         rec; /* ngx_rtmp_record_app_conf_t * */
+    ngx_flag_t                          align_interval;
 } ngx_rtmp_record_app_conf_t;
 
 


### PR DESCRIPTION
If interval recording enabled, the option makes the module to
recreate the dump file precisely at the interval boundaries, and
the first interval can be trancated by the boundary.

E.g. if you start recording at 10:10:15 and the interval is 30
seconds, if the option is "off", the files will be created at
10:10:45, 10:11:15 and so on. If the option is enabled, the times
are 10:10:30, 10:11:00, 10:11:30 etc.