### PR TITLE
Support of seq scaling list present while parsing SPS

### DIFF
--- a/ngx_rtmp_bitop.c
+++ b/ngx_rtmp_bitop.c
@@ -61,3 +61,15 @@ ngx_rtmp_bit_read_golomb(ngx_rtmp_bit_reader_t *br)
 
     return ((uint64_t) 1 << n) + ngx_rtmp_bit_read(br, n) - 1;
 }
+
+int64_t
+ngx_rtmp_bit_read_golomb_signed(ngx_rtmp_bit_reader_t *br)
+{
+    uint64_t value;
+    value = ngx_rtmp_bit_read_golomb(br);
+    if (value & 1) {
+        return (value / 2 + 1);
+    }
+    
+    return -(value / 2);
+}

--- a/ngx_rtmp_bitop.h
+++ b/ngx_rtmp_bitop.h
@@ -24,6 +24,7 @@ void ngx_rtmp_bit_init_reader(ngx_rtmp_bit_reader_t *br, u_char *pos,
     u_char *last);
 uint64_t ngx_rtmp_bit_read(ngx_rtmp_bit_reader_t *br, ngx_uint_t n);
 uint64_t ngx_rtmp_bit_read_golomb(ngx_rtmp_bit_reader_t *br);
+int64_t ngx_rtmp_bit_read_golomb_signed(ngx_rtmp_bit_reader_t *br);
 
 
 #define ngx_rtmp_bit_read_err(br) ((br)->err)


### PR DESCRIPTION
When try to stream FullHD video to nginx via rtmp it's important to take into consideration seq_scaling_lists values. This fix adds such logic
