### PR TITLE
fix for codec quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,15 @@ rtmp_auto_push directive.
                 root /path/to/stat.xsl/;
             }
 
+
+            # This URL provides RTMP statistics in json
+            location /json_stat {
+                rtmp_stat all;
+
+                # Stat output format valid values json or xml;
+                rtmp_stat_format json;
+            }
+
             location /hls {
                 # Serve HLS fragments
                 types {

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -673,6 +673,8 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_L("\",\"profile\":\"");
                         NGX_RTMP_STAT_CS(
                                 ngx_rtmp_stat_get_avc_profile(codec->avc_profile));
+                    } else {
+                         NGX_RTMP_STAT_L("\"");
                     }
                     if (codec->avc_compat) {
                         NGX_RTMP_STAT_L("\",\"compat\":");
@@ -684,9 +686,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
                     }
-                    if (!codec->avc_profile && !codec->avc_compat && !codec->avc_level) {
-                        NGX_RTMP_STAT_L("\"");
-                    }
+
 
                     NGX_RTMP_STAT_L("}, \"audio\": {");
                     cname = ngx_rtmp_get_audio_codec_name(codec->audio_codec_id);

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -668,12 +668,13 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_L(",\"codec\":\"");
                         NGX_RTMP_STAT_ECS(cname);
                     }
+                    
                     if (codec->avc_profile) {
                         NGX_RTMP_STAT_L("\",\"profile\":\"");
                         NGX_RTMP_STAT_CS(
                                 ngx_rtmp_stat_get_avc_profile(codec->avc_profile));
                     }
-                    if (codec->avc_level) {
+                    if (codec->avc_compat) {
                         NGX_RTMP_STAT_L("\",\"compat\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->avc_compat) - buf);
@@ -683,6 +684,11 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
                     }
+                                        if (!codec->avc_profile && !codec->avc_compat && !codec->avc_level) {
+                                                
+                    NGX_RTMP_STAT_L("\"");
+
+}
 
                     NGX_RTMP_STAT_L("}, \"audio\": {");
                     cname = ngx_rtmp_get_audio_codec_name(codec->audio_codec_id);

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -684,11 +684,9 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
                     }
-                                        if (!codec->avc_profile && !codec->avc_compat && !codec->avc_level) {
-                                                
-                    NGX_RTMP_STAT_L("\"");
-
-}
+                    if (!codec->avc_profile && !codec->avc_compat && !codec->avc_level) {
+                        NGX_RTMP_STAT_L("\"");
+                    }
 
                     NGX_RTMP_STAT_L("}, \"audio\": {");
                     cname = ngx_rtmp_get_audio_codec_name(codec->audio_codec_id);


### PR DESCRIPTION
if no codec->avc_profile is necessary to close codec quote.

In addition seems that 

```
  if (codec->avc_level) {
                          NGX_RTMP_STAT_L("\",\"compat\":");		                          NGX_RTMP_STAT_L("\",\"compat\":");
                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),		                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                        "%ui", codec->avc_compat) - buf);		                                        "%ui", codec->avc_compat) - buf);
 @@ -683,6 +684,11 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),		                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                        "%.1f", codec->avc_level / 10.) - buf);		                                        "%.1f", codec->avc_level / 10.) - buf);
                      }		                      }

```
would be 

```
  if (codec->avc_compat) {
                          NGX_RTMP_STAT_L("\",\"compat\":");		                          NGX_RTMP_STAT_L("\",\"compat\":");
                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),		                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                        "%ui", codec->avc_compat) - buf);		                                        "%ui", codec->avc_compat) - buf);
 @@ -683,6 +684,11 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),		                          NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                        "%.1f", codec->avc_level / 10.) - buf);		                                        "%.1f", codec->avc_level / 10.) - buf);
                      }		                      }

```

but i'm not sure