### PR TITLE
delete init_session space

### DIFF
--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -149,7 +149,7 @@ ngx_rtmp_init_session(ngx_connection_t *c, ngx_rtmp_addr_conf_t *addr_conf)
 
     s = ngx_pcalloc(c->pool, sizeof(ngx_rtmp_session_t) +
             sizeof(ngx_chain_t *) * ((ngx_rtmp_core_srv_conf_t *)
-                addr_conf->ctx-> srv_conf[ngx_rtmp_core_module
+                addr_conf->ctx->srv_conf[ngx_rtmp_core_module
                     .ctx_index])->out_queue);
     if (s == NULL) {
         ngx_rtmp_close_connection(c);


### PR DESCRIPTION
in function ngx_rtmp_init_session, there is a excess space.