### PR TITLE
Fix DASH validation - added publishTime attribute to DASH manifests.

### DIFF
--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -382,7 +382,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     p = ngx_slprintf(buffer, last, NGX_RTMP_DASH_MANIFEST_HEADER,
                      start_time,
                      end_time,
-					 publish_time,
+                     publish_time,
                      (ngx_uint_t) (dacf->fraglen / 1000),
                      (ngx_uint_t) (dacf->fraglen / 1000),
                      (ngx_uint_t) (dacf->fraglen / 500));


### PR DESCRIPTION
DASH manifest wasn't validating. It was missing the publishTime attribute in the manifest XML.