### PR TITLE
Update ngx_rtmp.c

### DIFF
--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -293,6 +293,7 @@ ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
     }
 
+    cf->ctx = ctx;
 
     if (ngx_rtmp_init_events(cf, cmcf) != NGX_OK) {
         return NGX_CONF_ERROR;


### PR DESCRIPTION
Hello!

As I think, currently all the postconfiguration handlers are called with a wrong context assigned to cf->ctx.

IMHO, they shall be called with the rtmp block's context (as preconfiguration handlers are), but indeed they are called with the context of the very last server block observed in the rtmp configuration. This happens due to context switching performed in the line 254: "cf->ctx = cscfp[s]->ctx;" -- which is not undone after the work is completed prior to enter the postconfiguration cycle.

Fortunately all the modules in the rtmp suite did not faced this fact yet as soon as both the rtmp block's context and all the server blocks' contexts have exactly the same main_conf part, while neither srv_conf nor app_conf parts are actually used by existing postconfiguration handlers.

I propose to change this behavior and pass the rtmp block's context. To do this it's enough to add just one line of code.

I'm not 100% sure if my understanding is correct. So, please, verify my proposal.

Thank you!
- Alex