### PR TITLE
Also pass clientid in on_connect notify

### DIFF
--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -390,6 +390,7 @@ ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s, void *arg,
             sizeof("&tcurl=") - 1 + tc_url_len * 3 +
             sizeof("&pageurl=") - 1 + page_url_len * 3 +
             sizeof("&addr=") - 1 + addr_text->len * 3 +
+            sizeof("&clientid=") - 1 + NGX_INT_T_LEN +
             sizeof("&epoch=") - 1 + NGX_INT32_LEN +
             1 + args_len
         );
@@ -428,6 +429,10 @@ ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s, void *arg,
     b->last = ngx_cpymem(b->last, (u_char*) "&addr=", sizeof("&addr=") -1);
     b->last = (u_char*) ngx_escape_uri(b->last, addr_text->data,
                                        addr_text->len, NGX_ESCAPE_ARGS);
+
+    b->last = ngx_cpymem(b->last, (u_char*) "&clientid=",
+                         sizeof("&clientid=") - 1);
+    b->last = ngx_sprintf(b->last, "%ui", (ngx_uint_t) s->connection->number);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&epoch=", sizeof("&epoch=") -1);
     b->last = ngx_sprintf(b->last, "%uD", (uint32_t) s->epoch);


### PR DESCRIPTION
It's useful to be able to associate the connect notify with a later play or publish notify for the same connection.