### PR TITLE
Fix a couple of typos

### DIFF
--- a/ngx_rtmp_exec_module.c
+++ b/ngx_rtmp_exec_module.c
@@ -640,7 +640,7 @@ ngx_rtmp_exec_child_dead(ngx_event_t *ev)
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, e->log, 0,
-                   "exec: shedule respawn %Mmsec", e->respawn_timeout);
+                   "exec: schedule respawn %Mmsec", e->respawn_timeout);
 
     e->respawn_evt.data = e;
     e->respawn_evt.log = e->log;

--- a/ngx_rtmp_limit_module.c
+++ b/ngx_rtmp_limit_module.c
@@ -105,7 +105,7 @@ ngx_rtmp_limit_connect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     rc = n > (ngx_uint_t) lmcf->max_conn ? NGX_ERROR : NGX_OK;
 
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "limit: inc conection counter: %uD", n);
+                   "limit: inc connection counter: %uD", n);
 
     if (rc != NGX_OK) {
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
@@ -141,7 +141,7 @@ ngx_rtmp_limit_disconnect(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     (void) n;
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "limit: dec conection counter: %uD", n);
+                   "limit: dec connection counter: %uD", n);
 
     return NGX_OK;
 }


### PR DESCRIPTION
As caught by lintian:

```
I: libnginx-mod-rtmp: spelling-error-in-binary usr/lib/nginx/modules/ngx_rtmp_module.so shedule schedule
I: libnginx-mod-rtmp: spelling-error-in-binary usr/lib/nginx/modules/ngx_rtmp_module.so conection connection
```