### PR TITLE
Allow hostnames in on_publish redirects

### DIFF
--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -1063,7 +1063,7 @@ ngx_rtmp_notify_publish_handle(ngx_rtmp_session_t *s,
     u->url.len = rc - 7;
     u->default_port = 1935;
     u->uri_part = 1;
-    u->no_resolve = 1; /* want ip here */
+    u->no_resolve = 0;
 
     if (ngx_parse_url(s->connection->pool, u) != NGX_OK) {
         ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,


### PR DESCRIPTION
Allows hostnames in 301/302 redirects with the `on_publish` callback (actually, only IP addresses work).