### PR TITLE
Add  "fall through" comments to stop GCC 7 complaining

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -1951,6 +1951,7 @@ ngx_rtmp_hls_video(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                                       "hls: error appending AUD NAL");
                     }
+                    /* fall through */
                 case 9:
                     aud_sent = 1;
                     break;

--- a/ngx_rtmp_access_module.c
+++ b/ngx_rtmp_access_module.c
@@ -410,8 +410,8 @@ ngx_rtmp_access_rule(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             break;
         }
 
-        /* "all" passes through */
 #endif
+        /* fall through */
 
     default: /* AF_INET */
 

--- a/ngx_rtmp_amf.c
+++ b/ngx_rtmp_amf.c
@@ -331,6 +331,7 @@ ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
                     if (elts->type & NGX_RTMP_AMF_OPTIONAL) {
                         return NGX_OK;
                     }
+                    /* fall through */
                 case NGX_ERROR:
                     return NGX_ERROR;
             }
@@ -398,6 +399,7 @@ ngx_rtmp_amf_read(ngx_rtmp_amf_ctx_t *ctx, ngx_rtmp_amf_elt_t *elts,
                 if (ngx_rtmp_amf_get(ctx, &max_index, 4) != NGX_OK) {
                     return NGX_ERROR;
                 }
+                /* fall through */
 
             case NGX_RTMP_AMF_OBJECT:
                 if (ngx_rtmp_amf_read_object(ctx, data,
@@ -592,6 +594,7 @@ ngx_rtmp_amf_write(ngx_rtmp_amf_ctx_t *ctx,
                 if (ngx_rtmp_amf_put(ctx, &max_index, 4) != NGX_OK) {
                     return NGX_ERROR;
                 }
+                /* fall through */
 
             case NGX_RTMP_AMF_OBJECT:
                 type8 = NGX_RTMP_AMF_END;

--- a/ngx_rtmp_eval.c
+++ b/ngx_rtmp_eval.c
@@ -154,6 +154,7 @@ ngx_rtmp_eval(void *ctx, ngx_str_t *in, ngx_rtmp_eval_t **e, ngx_str_t *out,
 
                 name.len = p - name.data;
                 ngx_rtmp_eval_append_var(ctx, &b, e, &name, log);
+                /* fall through */
 
             case NORMAL:
                 switch (c) {

--- a/ngx_rtmp_init.c
+++ b/ngx_rtmp_init.c
@@ -79,6 +79,7 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
         case AF_UNIX:
             unix_socket = 1;
+            /* fall through */
 
         default: /* AF_INET */
             sin = (struct sockaddr_in *) sa;
@@ -110,6 +111,7 @@ ngx_rtmp_init_connection(ngx_connection_t *c)
 
         case AF_UNIX:
             unix_socket = 1;
+            /* fall through */
 
         default: /* AF_INET */
             addr = port->addrs;

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -892,6 +892,7 @@ ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
 
                     n = 0;
                     state = parse_name;
+                    /* fall through */
 
                 case parse_name:
                     switch (c) {
@@ -919,6 +920,7 @@ ngx_rtmp_notify_parse_http_header(ngx_rtmp_session_t *s,
                         break;
                     }
                     state = parse_value;
+                    /* fall through */
 
                 case parse_value:
                     if (c == '\n') {


### PR DESCRIPTION
Without these comments gcc7 will complain (-Wimplicit-fallthrough).

This fixes #1109.