### PR TITLE
In hls / ngx_rtmp_hls_module.c in the first 2346th line and 2421 line…

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -2343,7 +2343,7 @@ ngx_rtmp_hls_merge_app_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_str_value(conf->base_url, prev->base_url, "");
     ngx_conf_merge_value(conf->granularity, prev->granularity, 0);
     ngx_conf_merge_value(conf->keys, prev->keys, 0);
-    ngx_conf_merge_str_value(conf->key_path, prev->key_path, "");
+    /* ngx_conf_merge_str_value(conf->key_path, prev->key_path, "");*/
     ngx_conf_merge_str_value(conf->key_url, prev->key_url, "");
     ngx_conf_merge_uint_value(conf->frags_per_key, prev->frags_per_key, 0);
 


### PR DESCRIPTION
nginx.conf  `hls_key_path /tmp/hlskeys;`
start nginx 
```bash
nginx: [emerg] the same path name "/data/hlskeys" used in /usr/local/nginx/conf/nginx.conf:178 and in /usr/local/nginx/conf/nginx.conf:178
```
In hls / ngx_rtmp_hls_module.c in the first 2346th line and 2421 lines should be removed twice the line or comment out the 2346 on a [I am here temporarily commented out] to prevent nginx dished out configuration error Nginx: [emerg] The same path is used in the following languages.

![359f25a4-d41d-11e6-9bca-97659c9b6d2f](https://user-images.githubusercontent.com/14959876/33196454-2927736c-d11a-11e7-9ee9-45bfc69212f4.png)


