### PR TITLE
Now nginx rtmp module support chunk size larger than NGX_RTMP_MAX_C…

### DIFF
--- a/ngx_rtmp_handler.c
+++ b/ngx_rtmp_handler.c
@@ -821,16 +821,10 @@ ngx_rtmp_set_chunk_size(ngx_rtmp_session_t *s, ngx_uint_t size)
     ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
         "setting chunk_size=%ui", size);
 
-    if (size > NGX_RTMP_MAX_CHUNK_SIZE) {
-        ngx_log_error(NGX_LOG_ALERT, s->connection->log, 0,
-                      "too big RTMP chunk size:%ui", size);
-        return NGX_ERROR;
-    }
-
     cscf = ngx_rtmp_get_module_srv_conf(s, ngx_rtmp_core_module);
 
     s->in_old_pool = s->in_pool;
-    s->in_chunk_size = size;
+    s->in_chunk_size = (size > NGX_RTMP_MAX_CHUNK_SIZE)? NGX_RTMP_MAX_CHUNK_SIZE : size;
     s->in_pool = ngx_create_pool(4096, s->connection->log);
 
     /* copy existing chunk data */


### PR DESCRIPTION
This pull request aim is to make nginx-rtmp-module compatible with [MonaServer](https://github.com/MonaSolutions/MonaServer2) and possibly other servers.

**Explanation :** There is no need to forbid chunk size larger than NGX_RTMP_MAX_CHUNK_SIZE in the SetChunkSize request. From the RTMP Specification : 

> chunk size (31 bits): This field holds the new maximum chunk size,
> in bytes, which will be used for all of the sender’s subsequent
> chunks until further notice. Valid sizes are 1 to 2147483647
> (0x7FFFFFFF) inclusive; however, all sizes greater than 16777215
> (0xFFFFFF) are equivalent since no chunk is larger than one
> message, and no message is larger than 16777215 bytes.