### PR TITLE
Fixed URI encoding error in HTTP notify callbacks for URL values that have more than one querystring argument

### DIFF
--- a/ngx_rtmp_netcall_module.c
+++ b/ngx_rtmp_netcall_module.c
@@ -608,17 +608,17 @@ ngx_rtmp_netcall_http_format_session(ngx_rtmp_session_t *s, ngx_pool_t *pool)
     b->last = ngx_cpymem(b->last, (u_char*) "&swfurl=",
                          sizeof("&swfurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, s->swf_url.data,
-                                       s->swf_url.len, NGX_ESCAPE_ARGS);
+                                       s->swf_url.len, NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&tcurl=",
                          sizeof("&tcurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, s->tc_url.data,
-                                       s->tc_url.len, NGX_ESCAPE_ARGS);
+                                       s->tc_url.len, NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&pageurl=",
                          sizeof("&pageurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, s->page_url.data,
-                                       s->page_url.len, NGX_ESCAPE_ARGS);
+                                       s->page_url.len, NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&addr=", sizeof("&addr=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, addr_text->data,

--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -413,17 +413,17 @@ ngx_rtmp_notify_connect_create(ngx_rtmp_session_t *s, void *arg,
     b->last = ngx_cpymem(b->last, (u_char*) "&swfurl=",
                          sizeof("&swfurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, v->swf_url, swf_url_len,
-                                       NGX_ESCAPE_ARGS);
+                                       NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&tcurl=",
                          sizeof("&tcurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, v->tc_url, tc_url_len,
-                                       NGX_ESCAPE_ARGS);
+                                       NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&pageurl=",
                          sizeof("&pageurl=") - 1);
     b->last = (u_char*) ngx_escape_uri(b->last, v->page_url, page_url_len,
-                                       NGX_ESCAPE_ARGS);
+                                       NGX_ESCAPE_URI_COMPONENT);
 
     b->last = ngx_cpymem(b->last, (u_char*) "&addr=", sizeof("&addr=") -1);
     b->last = (u_char*) ngx_escape_uri(b->last, addr_text->data,


### PR DESCRIPTION
Changed encoding of three query args that are themselves URLs (swfurl,
tcurl, and pageurl) that should be encoded as URI components (rather
than just ESCAPEd) to prevent double encoding errors. If NGX_ESCAPE_ARGS
is used to escape a swfurl value of

  'http://example.com/?arg1=val1&arg2=val2'

the key/value pair of arg2/val2 would lose association with swfurl, and
will appear as a property or argument in the same context as swfurl,
tcurl, pageurl, etc. Encoding as a URI component ensures encapsulation
of this value isn't broken.