### PR TITLE
Use segment timeline repetitions to output smaller manifests

### DIFF
--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -211,7 +211,7 @@ ngx_rtmp_dash_rename_file(u_char *src, u_char *dst)
 #endif
 }
 
-static u_char
+static u_char *
 ngx_rtmp_dash_write_segment(u_char *p, u_char *last, ngx_uint_t t, ngx_uint_t d, ngx_uint_t r)
 {
 #define NGX_RTMP_DASH_MANIFEST_TIME                                            \
@@ -227,13 +227,16 @@ ngx_rtmp_dash_write_segment(u_char *p, u_char *last, ngx_uint_t t, ngx_uint_t d,
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME_WITH_REPETITION,
                          t, d, r);
     }
+
+    return p;
 }
 
-static u_char
+static u_char *
 ngx_rtmp_dash_write_segment_timeline(ngx_rtmp_session_t *s, ngx_rtmp_dash_ctx_t *ctx, u_char *p, u_char *last)
 {
 
-    ngx_uint_t i, t, d, r;
+    ngx_uint_t              i, t, d, r;
+    ngx_rtmp_dash_frag_t    *f;
 
     for (i = 0; i < ctx->nfrags; i++) {
         f = ngx_rtmp_dash_get_frag(s, i);
@@ -271,10 +274,8 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     ngx_fd_t                   fd;
     struct tm                  tm;
     ngx_str_t                  noname, *name;
-    ngx_uint_t                 i;
     ngx_rtmp_dash_ctx_t       *ctx;
     ngx_rtmp_codec_ctx_t      *codec_ctx;
-    ngx_rtmp_dash_frag_t      *f;
     ngx_rtmp_dash_app_conf_t  *dacf;
 
     static u_char              buffer[NGX_RTMP_DASH_BUFSIZE];

--- a/dash/ngx_rtmp_dash_module.c
+++ b/dash/ngx_rtmp_dash_module.c
@@ -211,6 +211,22 @@ ngx_rtmp_dash_rename_file(u_char *src, u_char *dst)
 #endif
 }
 
+static u_char
+ngx_rtmp_dash_write_segments(ngx_rtmp_session_t *s, ngx_rtmp_dash_ctx_t *ctx, u_char *p, u_char *last)
+{
+#define NGX_RTMP_DASH_MANIFEST_TIME                                            \
+    "             <S t=\"%uD\" d=\"%uD\"/>\n"
+
+
+    for (i = 0; i < ctx->nfrags; i++) {
+        f = ngx_rtmp_dash_get_frag(s, i);
+        p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME,
+                         f->timestamp, f->duration);
+    }
+
+    return p;
+}
+
 
 static ngx_int_t
 ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
@@ -298,11 +314,6 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
     "      </Representation>\n"                                                \
     "    </AdaptationSet>\n"
 
-
-#define NGX_RTMP_DASH_MANIFEST_TIME                                            \
-    "             <S t=\"%uD\" d=\"%uD\"/>\n"
-
-
 #define NGX_RTMP_DASH_MANIFEST_AUDIO                                           \
     "    <AdaptationSet\n"                                                     \
     "        id=\"2\"\n"                                                       \
@@ -387,11 +398,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
                          name, sep,
                          name, sep);
 
-        for (i = 0; i < ctx->nfrags; i++) {
-            f = ngx_rtmp_dash_get_frag(s, i);
-            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME,
-                             f->timestamp, f->duration);
-        }
+        p = ngx_rtmp_dash_write_segments(s, ctx, p, last);
 
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_VIDEO_FOOTER);
 
@@ -408,11 +415,7 @@ ngx_rtmp_dash_write_playlist(ngx_rtmp_session_t *s)
                          name, sep,
                          name, sep);
 
-        for (i = 0; i < ctx->nfrags; i++) {
-            f = ngx_rtmp_dash_get_frag(s, i);
-            p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_TIME,
-                             f->timestamp, f->duration);
-        }
+        p = ngx_rtmp_dash_write_segments(s, ctx, p, last);
 
         p = ngx_slprintf(p, last, NGX_RTMP_DASH_MANIFEST_AUDIO_FOOTER);
 


### PR DESCRIPTION
Currently each segment will be outputed as a different line in the manifest's segment timeline. However, the dash spec allows to use the attribute `r` when `r` consecutive segments have the same duration, instead of having to sepcify a `S` tag for each of them.
This is very useful for manifests with long DVR window and constant segment duration, where the timeline can be sumed up in a single line instead of thousands.