### PR TITLE
Fix stackflow

### DIFF
--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -542,7 +542,7 @@ ngx_rtmp_codec_dump_header(ngx_rtmp_session_t *s, const char *type,
     u_char hex[] = "0123456789abcdef";
 
     for (pp = buf, p = in->buf->pos;
-         p < in->buf->last && pp < buf + sizeof(buf) - 1;
+         p < in->buf->last && pp < buf + sizeof(buf) - 2;
          ++p)
     {
         *pp++ = hex[*p >> 4];


### PR DESCRIPTION
When but_size >=128, *pp = 0 will write out of buf.