### PR TITLE
Fixed counting the number of elements in queue

### DIFF
--- a/ngx_rtmp_handler.c
+++ b/ngx_rtmp_handler.c
@@ -712,7 +712,9 @@ ngx_rtmp_send_message(ngx_rtmp_session_t *s, ngx_chain_t *out,
 {
     ngx_uint_t                      nmsg;
 
-    nmsg = (s->out_last - s->out_pos) % s->out_queue + 1;
+    nmsg = ((s->out_pos <= s->out_last)
+        ? s->out_last - s->out_pos
+        : (s->out_queue - s->out_pos) + s->out_last) + 1;
 
     if (priority > 3) {
         priority = 3;


### PR DESCRIPTION
Previous logic does not check when the queue size is negative.
As a result, logic that determines whether a packet is dropped may not work correctly.