### PR TITLE
hls: fix redirected stream name

### DIFF
--- a/config
+++ b/config
@@ -16,11 +16,11 @@ RTMP_CORE_MODULES="                                         \
                 ngx_rtmp_exec_module                        \
                 ngx_rtmp_auto_push_module                   \
                 ngx_rtmp_auto_push_index_module             \
-                ngx_rtmp_notify_module                      \
                 ngx_rtmp_log_module                         \
                 ngx_rtmp_limit_module                       \
                 ngx_rtmp_hls_module                         \
                 ngx_rtmp_dash_module                        \
+                ngx_rtmp_notify_module                      \
                 "
 
 


### PR DESCRIPTION
Fixes on_publish redirection to the new stream name based on the location header