### PR TITLE
Fix nested HLS directories permission

### DIFF
--- a/hls/ngx_rtmp_hls_module.c
+++ b/hls/ngx_rtmp_hls_module.c
@@ -30,7 +30,7 @@ static ngx_int_t ngx_rtmp_hls_ensure_directory(ngx_rtmp_session_t *s,
 
 
 #define NGX_RTMP_HLS_BUFSIZE            (1024*1024)
-#define NGX_RTMP_HLS_DIR_ACCESS         0744
+#define NGX_RTMP_HLS_DIR_ACCESS         0755
 
 
 typedef struct {


### PR DESCRIPTION
0744 doesn't make sense as it allows other processes to read the files but not enter the directory, this change sets the execute bit so other users (such as PHP processes) can access these files.