### PR TITLE
add forward_auth to redirect parameters from source to target with push

### DIFF
--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -679,7 +679,7 @@ ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-	//safa adding args (auth) to the name
+	//safe adding args (auth) to the name
 	if(racf->forward_auth)
 	{
 		ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
@@ -800,7 +800,7 @@ ngx_rtmp_relay_play_local(ngx_rtmp_session_t *s)
         return NGX_ERROR;
     }
 	int arg_pos = 0;
-	for(int c = 0 ; c < ctx->name.len ; c++)
+	for(int c = 0 ; c < (int)(ctx->name.len) ; c++)
 	{
 		if (ctx->name.data[c] == '?')
 		{

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -56,7 +56,7 @@ typedef struct {
     ngx_msec_t                  push_reconnect;
     ngx_msec_t                  pull_reconnect;
     ngx_rtmp_relay_ctx_t        **ctx;
-	ngx_flag_t                  forward_auth;
+	ngx_flag_t                  forward_auth;									  
 } ngx_rtmp_relay_app_conf_t;
 
 
@@ -679,13 +679,19 @@ ngx_rtmp_relay_publish(ngx_rtmp_session_t *s, ngx_rtmp_publish_t *v)
         goto next;
     }
 
-	//safe adding args (auth) to the name
+	//safa adding args (auth) to the name
 	if(racf->forward_auth)
 	{
+		ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+			"relay: name='%s' args='%s'",
+			v->name, v->args);
+
 		name.len = ngx_strlen(v->name) + ngx_strlen(v->args) + 1;
 		name.data = ngx_palloc(s->connection->pool, name.len + 1);
 
 		if (name.data == NULL) {
+			ngx_log_error(NGX_LOG_INFO, s->connection->log, 0,
+					  "what the heck");
 			return NGX_ERROR;
 		}
 		*ngx_cpymem(name.data, v->name, ngx_strlen(v->name)) = 0;


### PR DESCRIPTION
Add `forward_auth` to allow push stream with attached authentification.

Example : 

```
worker_processes auto;
rtmp_auto_push on;
rtmp_auto_push_reconnect 1s;
events {}
rtmp {
    server {
        listen 1935;
        listen [::]:1935 ipv6only=on;
        chunk_size 4096;

        application live {
            live on;
            record off;
            push rtmp://127.0.0.1:19350/live;
            forward_auth on;
        }
        
    }
}
```
 
Related issue #920