### PR TITLE
fix: add https for notify url

### DIFF
--- a/ngx_rtmp_notify_module.c
+++ b/ngx_rtmp_notify_module.c
@@ -1555,6 +1555,7 @@ ngx_rtmp_notify_parse_url(ngx_conf_t *cf, ngx_str_t *url)
     size_t      port;
 
     add = 0;
+    port = 80;
 
     u = ngx_pcalloc(cf->pool, sizeof(ngx_url_t));
     if (u == NULL) {


### PR DESCRIPTION
When using the `ngx_rtmp_notify_commands` for different events such as `on_connect` or `on_publish`, we want to notify an authentication service. 

We use these directives in the `nginx.conf` and provide the URL of the authentication service.

However it doesn't work when the authentication service is using `https`.

This is because the `ngx_rtmp_notify_parse_url` in `ngx_rtmp_notify_module.c` method does NOT handle https.
```
    if (ngx_strncasecmp(url->data, (u_char *)"http://", 7) == 0)
    {
        add = 7;
    }
```
I propose a very simple fix:
```
    if (ngx_strncasecmp(url->data, (u_char *)"http://", 7) == 0)
    {
        add = 7;
        port = 80
    }
    else if (ngx_strncasecmp(url->data, (u_char *)"https://", 8) == 0)
    {
        add = 8;
        port = 443;
    }
```
This fix is very similar to these:
https://mailman.nginx.org/pipermail/nginx-devel/2013-August/004065.html
https://github.com/kaltura/nginx-aws-auth-module/blob/dbbac974f0699328a63f497cd911a4f991faed9b/ngx_http_aws_auth_module.c#L992-L1009