### PR TITLE
fix donation page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### Donation page (Paypal etc)
 
-  http://arut.github.com/nginx-rtmp-module/
+  https://arut.github.io/nginx-rtmp-module/
 
 ### Features
 


### PR DESCRIPTION
I wanted to donate, but the link was broken. Replacing `.com` with `.io` fixes it.