### PR TITLE
fix exec_* startup delay if nofile is too high

### DIFF
--- a/ngx_rtmp_exec_module.c
+++ b/ngx_rtmp_exec_module.c
@@ -778,13 +778,8 @@ ngx_rtmp_exec_run(ngx_rtmp_exec_t *e)
             /* close all descriptors but pipe write end */
 
             maxfd = sysconf(_SC_OPEN_MAX);
-            for (fd = 0; fd < maxfd; ++fd) {
-                if (fd == pipefd[1]) {
-                    continue;
-                }
-
-                close(fd);
-            }
+            close_range(0, pipefd[1] - 1, 0);
+            close_range(pipefd[1] + 1, maxfd - 1, 0);
 
             fd = open("/dev/null", O_RDWR);
 


### PR DESCRIPTION
Currently we rely on a for loop to close all possible file descriptors, and when nofile is set to a large number (a very common case in Nginx deployments), the worker process might eat up a single core for a few minutes(!) after `fork` and before `exec`. This results in unexpected server performance impacts, and causes `exec_push` and `exec_pull` to be delayed a lot (e.g. you can't do low-latency realtime transcode anymore). [Others have pointed out this problem](https://blog.timo.page/fixing-nginx-rtmp-exec-in-docker) but lowering nofiles is not a long term solution.

This patch resolves the performance issue, and have been steadily runnning in my environment for a while. But it requires Linux 5.9 + glibc 2.34, or FreeBSD 8.0+. I'm not sure if we can detect the existence of `close_range` in `configure` as I'm not really familiar of Nginx's build system conventions. I'd like to refine its compatibility if possible.