### PR TITLE
Fix receive amf checking

### DIFF
--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1292,12 +1292,18 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         if (ngx_rtmp_receive_amf(s, in, in_elts_meta,
                              sizeof(in_elts_meta) / sizeof(in_elts_meta[0])) != NGX_OK)
         {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "relay: failed to parse AMF message");
+                      
             return NGX_ERROR;
         }
     } else {
         if (ngx_rtmp_receive_amf(s, in, in_elts,
                                  sizeof(in_elts) / sizeof(in_elts[0])) != NGX_OK)
         {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "relay: failed to parse AMF metadata");
+
             return NGX_ERROR;
         }
     }

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1293,8 +1293,8 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                              sizeof(in_elts_meta) / sizeof(in_elts_meta[0])) != NGX_OK)
         {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                      "relay: failed to parse AMF message");
-                      
+                      "relay: failed to parse AMF metadata");
+
             return NGX_ERROR;
         }
     } else {
@@ -1302,7 +1302,7 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
                                  sizeof(in_elts) / sizeof(in_elts[0])) != NGX_OK)
         {
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
-                      "relay: failed to parse AMF metadata");
+                      "relay: failed to parse AMF message");
 
             return NGX_ERROR;
         }

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1289,11 +1289,17 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_memzero(&v, sizeof(v));
     if (h->type == NGX_RTMP_MSG_AMF_META) {
-        ngx_rtmp_receive_amf(s, in, in_elts_meta,
-                sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts_meta,
+                             sizeof(in_elts_meta) / sizeof(in_elts_meta[0])) != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
     } else {
-        ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts,
+                                 sizeof(in_elts) / sizeof(in_elts[0])) != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,


### PR DESCRIPTION
The Svace static analysis tool identified a potential issue in the function `ngx_rtmp_relay_on_status`(), where the return value of `ngx_rtmp_receive_amf()` is not checked (line 1292):
```c
ngx_rtmp_receive_amf(s, in, in_elts_meta,
        sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
```

The function `ngx_rtmp_receive_amf()` calls `ngx_rtmp_amf_read()`, which can return NGX_ERROR in case of a parsing failure. However, no error handling is performed, and the function `ngx_rtmp_relay_on_status()` always returns NGX_OK, even if parsing fails.

So, the solution is to add error checking: 

```diff
@@ -1289,11 +1289,23 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,

    ngx_memzero(&v, sizeof(v));
    if (h->type == NGX_RTMP_MSG_AMF_META) {
-        ngx_rtmp_receive_amf(s, in, in_elts_meta,
-                sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts_meta,
+                             sizeof(in_elts_meta) / sizeof(in_elts_meta[0])) != NGX_OK)
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "relay: failed to parse AMF metadata");
+
+            return NGX_ERROR;
+        }
    } else {
-        ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts,
+                                 sizeof(in_elts) / sizeof(in_elts[0])) != NGX_OK)
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "relay: failed to parse AMF message");
+
+            return NGX_ERROR;
+        }
    }

    ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
```