### PR TITLE
Fixing unchecked value

### DIFF
--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -449,7 +449,9 @@ ngx_rtmp_init_event_handlers(ngx_conf_t *cf, ngx_rtmp_core_main_conf_t *cmcf)
     *eh = ngx_rtmp_aggregate_message_handler;
 
     /* init amf callbacks */
-    ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t));
+    if (ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t)) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     h = cmcf->amf.elts;
     for(n = 0; n < cmcf->amf.nelts; ++n, ++h) {

--- a/ngx_rtmp_play_module.c
+++ b/ngx_rtmp_play_module.c
@@ -733,6 +733,13 @@ ngx_rtmp_play_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 
     if (ctx == NULL) {
         ctx = ngx_palloc(s->connection->pool, sizeof(ngx_rtmp_play_ctx_t));
+
+        if (ctx == NULL) {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                          "play: failed to allocate play context");
+            return NGX_ERROR; 
+        }
+        
         ngx_rtmp_set_ctx(s, ctx, ngx_rtmp_play_module);
     }
 

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1292,8 +1292,13 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         ngx_rtmp_receive_amf(s, in, in_elts_meta,
                 sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
     } else {
-        ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts,
+            sizeof(in_elts) / sizeof(in_elts[0])))
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                 "relay: ngx_rtmp_receive_amf failed");
+            return NGX_OK;
+        }
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,


### PR DESCRIPTION
The Svace static analysis tool identified a potential issue in the function `ngx_rtmp_init_event_handlers()`, where the return value of `ngx_array_init` is not checked properly:

```c
 ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t));
```

The function сan return NGX_ERROR. However, no error handling is performed.

So, the solution is to add error checking:

```diff
diff --git a/ngx_rtmp.c b/ngx_rtmp.c
index cde7432..fc0ef24 100644
--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -449,7 +449,9 @@ ngx_rtmp_init_event_handlers(ngx_conf_t *cf, ngx_rtmp_core_main_conf_t *cmcf)
     *eh = ngx_rtmp_aggregate_message_handler;
 
     /* init amf callbacks */
-    ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t));
+    if (ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t)) != NGX_OK) {
+        return NGX_ERROR;
+    }
```