### PR TITLE
fix: add NULL-checks for shared buffer allocation in ngx_rtmp_live_av

### DIFF
--- a/ngx_rtmp.c
+++ b/ngx_rtmp.c
@@ -449,7 +449,9 @@ ngx_rtmp_init_event_handlers(ngx_conf_t *cf, ngx_rtmp_core_main_conf_t *cmcf)
     *eh = ngx_rtmp_aggregate_message_handler;
 
     /* init amf callbacks */
-    ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t));
+    if (ngx_array_init(&cmcf->amf_arrays, cf->pool, 1, sizeof(ngx_hash_key_t)) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     h = cmcf->amf.elts;
     for(n = 0; n < cmcf->amf.nelts; ++n, ++h) {

--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -803,6 +803,11 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     }
 */
     rpkt = ngx_rtmp_append_shared_bufs(cscf, NULL, in);
+    if (rpkt == NULL) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "live: failed to append packet buffers");
+        return NGX_OK;
+    }
 
     ngx_rtmp_prepare_message(s, &ch, &lh, rpkt);
 
@@ -903,55 +908,78 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
             }
 
             dummy_audio = 0;
-            if (lacf->wait_video && h->type == NGX_RTMP_MSG_VIDEO &&
-                !pctx->cs[1].active)
+            if (lacf->wait_video
+                && h->type == NGX_RTMP_MSG_VIDEO
+                && !pctx->cs[1].active)
             {
                 dummy_audio = 1;
+        
                 if (aapkt == NULL) {
+        
                     aapkt = ngx_rtmp_alloc_shared_buf(cscf);
-                    ngx_rtmp_prepare_message(s, &clh, NULL, aapkt);
+                    if (aapkt == NULL) {
+                        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                                      "relay: failed to alloc dummy audio buffer");
+                        dummy_audio = 0;
+                    }
+                    else {
+                        ngx_rtmp_prepare_message(s, &clh, NULL, aapkt);
+                    }
                 }
             }
-
+        
             if (header || coheader) {
-
-                /* send absolute codec header */
-
+        
                 ngx_log_debug2(NGX_LOG_DEBUG_RTMP, ss->connection->log, 0,
                                "live: abs %s header timestamp=%uD",
                                type_s, lh.timestamp);
-
+        
                 if (header) {
                     if (apkt == NULL) {
                         apkt = ngx_rtmp_append_shared_bufs(cscf, NULL, header);
-                        ngx_rtmp_prepare_message(s, &lh, NULL, apkt);
+                        if (apkt == NULL) {
+                            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                                          "relay: failed to append header buffers");
+                        }
+                        else {
+                            ngx_rtmp_prepare_message(s, &lh, NULL, apkt);
+                        }
                     }
-
-                    rc = ngx_rtmp_send_message(ss, apkt, 0);
-                    if (rc != NGX_OK) {
-                        continue;
+        
+                    if (apkt) {
+                        rc = ngx_rtmp_send_message(ss, apkt, 0);
+                        if (rc != NGX_OK) {
+                            continue;
+                        }
                     }
                 }
-
+        
                 if (coheader) {
                     if (acopkt == NULL) {
                         acopkt = ngx_rtmp_append_shared_bufs(cscf, NULL, coheader);
-                        ngx_rtmp_prepare_message(s, &clh, NULL, acopkt);
+                        if (acopkt == NULL) {
+                            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                                          "relay: failed to append coheader buffers");
+                        }
+                        else {
+                            ngx_rtmp_prepare_message(s, &clh, NULL, acopkt);
+                        }
                     }
-
-                    rc = ngx_rtmp_send_message(ss, acopkt, 0);
-                    if (rc != NGX_OK) {
-                        continue;
+        
+                    if (acopkt) {
+                        rc = ngx_rtmp_send_message(ss, acopkt, 0);
+                        if (rc != NGX_OK) {
+                            continue;
+                        }
                     }
-
-                } else if (dummy_audio) {
+        
+                } else if (dummy_audio && aapkt) {
                     ngx_rtmp_send_message(ss, aapkt, 0);
                 }
-
-                cs->timestamp = lh.timestamp;
-                cs->active = 1;
+        
+                cs->timestamp  = lh.timestamp;
+                cs->active     = 1;
                 ss->current_time = cs->timestamp;
-
             } else {
 
                 /* send absolute packet */
@@ -962,7 +990,14 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
                 if (apkt == NULL) {
                     apkt = ngx_rtmp_append_shared_bufs(cscf, NULL, in);
-                    ngx_rtmp_prepare_message(s, &ch, NULL, apkt);
+                    if (apkt == NULL) {
+                        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                                      "relay: failed to append header buffers");
+                    }
+
+                    else {
+                        ngx_rtmp_prepare_message(s, &ch, NULL, apkt);
+                    }
                 }
 
                 rc = ngx_rtmp_send_message(ss, apkt, prio);

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1292,8 +1292,13 @@ ngx_rtmp_relay_on_status(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         ngx_rtmp_receive_amf(s, in, in_elts_meta,
                 sizeof(in_elts_meta) / sizeof(in_elts_meta[0]));
     } else {
-        ngx_rtmp_receive_amf(s, in, in_elts,
-                sizeof(in_elts) / sizeof(in_elts[0]));
+        if (ngx_rtmp_receive_amf(s, in, in_elts,
+            sizeof(in_elts) / sizeof(in_elts[0])))
+        {
+            ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                 "relay: ngx_rtmp_receive_amf failed");
+            return NGX_OK;
+        }
     }
 
     ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,

--- a/ngx_rtmp_relay_module.c
+++ b/ngx_rtmp_relay_module.c
@@ -1680,14 +1680,32 @@ ngx_rtmp_relay_postconfiguration(ngx_conf_t *cf)
 
 
     ch = ngx_array_push(&cmcf->amf);
+    if (ch == NULL) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "relay: failed to add amf handler");
+            return NGX_ERROR;
+    }
+
     ngx_str_set(&ch->name, "_result");
     ch->handler = ngx_rtmp_relay_on_result;
 
     ch = ngx_array_push(&cmcf->amf);
+    if (ch == NULL) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "relay: failed to add amf handler");
+        return NGX_ERROR;
+    }
+    
     ngx_str_set(&ch->name, "_error");
     ch->handler = ngx_rtmp_relay_on_error;
 
     ch = ngx_array_push(&cmcf->amf);
+    if (ch == NULL) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "relay: failed to add amf handler");
+        return NGX_ERROR;
+    }
+    
     ngx_str_set(&ch->name, "onStatus");
     ch->handler = ngx_rtmp_relay_on_status;
 


### PR DESCRIPTION
The Svace static analysis tool identified a potential issue in the function `ngx_rtmp_live_av`, where the return value of  `ngx_rtmp_append_shared_bufs` and `ngx_rtmp_alloc_shared_bufs` is not checked properly. After allocation or appending the value is sending to the function `ngx_rtmp_prepare_message` (or `ngx_rtmp_send_message`) which can cause the null-dereference.

So the solution is to add null-checking, like there:

``` diff
--- a/ngx_rtmp_live_module.c
+++ b/ngx_rtmp_live_module.c
@@ -803,6 +803,11 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     }
 */
     rpkt = ngx_rtmp_append_shared_bufs(cscf, NULL, in);
+    if (rpkt == NULL) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "live: failed to append packet buffers");
+        return NGX_OK;
+    }
 
     ngx_rtmp_prepare_message(s, &ch, &lh, rpkt);
 
```